### PR TITLE
🔧 Don't remove a param if you don't know what it does

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -325,7 +325,7 @@ $vcf_fh->close;
 my ( $lines, @regions_split ) = ( "", ());
 my @regions = keys %uniq_regions;
 my $chr_prefix_in_use = ( @regions and $regions[0] =~ m/^chr/ ? 1 : 0 );
-push( @regions_split, [ splice( @regions, 0 ) ] ) while @regions;
+push( @regions_split, [ splice( @regions, 0, 25000 ) ] ) while @regions;
 map{ my $region = join( " ", sort @{$_} ); $lines .= `$samtools faidx $ref_fasta $region` } @regions_split;
 foreach my $line ( grep( length, split( ">", $lines ))) {
     # Carefully split this FASTA entry, properly chomping newlines for long indels
@@ -347,7 +347,7 @@ if( $filter_vcf ) {
     # Query each variant locus on the filter VCF, using tabix, just like we used samtools earlier
     ( $lines, @regions_split ) = ( "", ());
     my @regions = keys %uniq_loci;
-    push( @regions_split, [ splice( @regions, 0 ) ] ) while @regions;
+    push( @regions_split, [ splice( @regions, 0, 25000 ) ] ) while @regions;
     # ::NOTE:: chr-prefix removal works safely here because ExAC is limited to 1..22, X, Y
     map{ my $loci = join( " ", map{s/^chr//; $_} @{$_} ); $lines .= `$tabix $filter_vcf $loci` } @regions_split;
     foreach my $line ( split( "\n", $lines )) {

--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -347,6 +347,7 @@ if( $filter_vcf ) {
     # Query each variant locus on the filter VCF, using tabix, just like we used samtools earlier
     ( $lines, @regions_split ) = ( "", ());
     my @regions = keys %uniq_loci;
+    # Third param is splice helps limit array size and prevents overloading samtool faidx call
     push( @regions_split, [ splice( @regions, 0, 25000 ) ] ) while @regions;
     # ::NOTE:: chr-prefix removal works safely here because ExAC is limited to 1..22, X, Y
     map{ my $loci = join( " ", map{s/^chr//; $_} @{$_} ); $lines .= `$tabix $filter_vcf $loci` } @regions_split;


### PR DESCRIPTION
Added back in a param that used to be called `$buffer` as an int to fix large input errors

<!--Pull Request Template-->

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Local test with any vcf input; command run was: ` perl /WORK/tools/kf-mskcc-vcf2maf/vcf2maf.pl --input-vcf input_file.vcf --output-maf FULL_MONTY.consensus.vep.maf --tumor-id BS_F5EX3ZY5 --normal-id BS_F0GNWEJJ --custom-enst /vcf2maf/data/isoform_overrides_uniprot --use-kf-fields --ncbi-build GRCh38  --ref-fasta /WORK/volume/mask_dev/Homo_sapiens_assembly38.fasta`
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
